### PR TITLE
fix: discovery icon bug

### DIFF
--- a/src/lib/components/common/Breadcrumbs.svelte
+++ b/src/lib/components/common/Breadcrumbs.svelte
@@ -16,6 +16,8 @@
 		switch (type) {
 			case 'library':
 				return 'library'
+			case 'discovery':
+				return 'globe'
 			case 'folder':
 				return 'folder'
 			case 'smart_playlist':

--- a/src/lib/stores/playlists.ts
+++ b/src/lib/stores/playlists.ts
@@ -488,7 +488,7 @@ export function buildBreadcrumbItems(
 	items.push({
 		id: null,
 		name: rootLabel,
-		type: 'library',
+		type: activeView === 'discovery' ? 'discovery' : 'library',
 	})
 
 	// Get path from root to target

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -401,7 +401,7 @@ export interface ContextMenuItem {
 // Breadcrumb Types
 // =============================================================================
 
-export type BreadcrumbType = 'library' | 'folder' | 'playlist' | 'smart_playlist'
+export type BreadcrumbType = 'library' | 'discovery' | 'folder' | 'playlist' | 'smart_playlist'
 
 export interface BreadcrumbItem {
 	id: string | null // null for Library root


### PR DESCRIPTION
## Summary

There was an issue with the wrong icon being used for discovery breadcrumbs.

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally
- [x] No unrelated changes included
