### PR TITLE
fix: modal dialog layout

### DIFF
--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -94,15 +94,14 @@
 
 <dialog
 	bind:this={dialogEl}
-	class="fixed inset-0 m-0 h-full max-h-none w-full max-w-none bg-transparent p-0 backdrop:bg-black/60"
+	class="fixed inset-0 m-0 flex h-full max-h-none w-full max-w-none items-center justify-center bg-transparent p-0 backdrop:bg-black/60"
 	onkeydown={handleKeydown}
 	onmousedown={handleBackdropMousedown}
 	onclick={handleBackdropClick}
 >
 	{#if visible}
 		<div
-			class="fixed top-1/2 left-1/2 flex max-h-[85vh] w-full {sizeClasses[size] ?? 'max-w-md'} -translate-x-1/2
-				-translate-y-1/2 flex-col rounded-lg border border-stroke bg-surface-1 text-text-primary shadow-xl"
+			class="flex max-h-[85vh] w-full {sizeClasses[size] ?? 'max-w-md'} flex-col rounded-lg border border-stroke bg-surface-1 text-text-primary shadow-xl"
 			transition:scale={{ start: 0.95, duration: 200 }}
 			onoutroend={handleOutroEnd}
 		>


### PR DESCRIPTION
## Related Issue

Closes #

## Summary (optional)

small css change to prevent the "add release" modal from getting clipped at the bottom. love the direction of the project btw.

**before:**
<img width="3424" height="2332" alt="CleanShot 2026-03-15 at 22 29 55@2x" src="https://github.com/user-attachments/assets/611d299e-9598-4b4d-970c-7cdc26a1f18c" />

**after:**
![CleanShot 2026-03-15 at 22 14 04](https://github.com/user-attachments/assets/8758c899-0a1d-4b29-a01a-bfcd2ee88048)


...

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally
- [x] No unrelated changes included
