### PR TITLE
fix: discovery row buttons import open url don't work in playlist view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added macOS keyboard shortcuts for hide/hide others/show all
+
+### Fixed
+
+- Fixed discovery row buttons (import and open URL) not working in playlist view
+
 ## [0.2.8] - 2026-03-15
 
 ### Added

--- a/src/lib/components/playlists/PlaylistView.svelte
+++ b/src/lib/components/playlists/PlaylistView.svelte
@@ -48,6 +48,8 @@
 		onTrackPlay?: (track: Track) => void
 		onDiscoveryTrackPlay?: (release: DiscoveryRelease, trackIndex: number) => void
 		onDiscoveryTrackLikeToggle?: (releaseId: string, trackId: string) => void
+		onReleaseImport?: (release: DiscoveryRelease) => void
+		onReleaseOpenUrl?: (release: DiscoveryRelease) => void
 		onSortChange?: (config: SortConfig) => void
 		discoverySortConfig?: DiscoverySortConfig
 		onDiscoverySortChange?: (config: DiscoverySortConfig) => void
@@ -91,6 +93,8 @@
 		onTrackPlay,
 		onDiscoveryTrackPlay,
 		onDiscoveryTrackLikeToggle,
+		onReleaseImport,
+		onReleaseOpenUrl,
 		onSortChange,
 		discoverySortConfig = { field: 'artist', direction: 'asc' },
 		onDiscoverySortChange,
@@ -241,6 +245,8 @@
 				onToggleExpand={(id) => expandedReleaseIds.toggle(id)}
 				onTrackPlay={onDiscoveryTrackPlay}
 				onTrackLikeToggle={onDiscoveryTrackLikeToggle}
+				{onReleaseImport}
+				{onReleaseOpenUrl}
 				{onScrollChange}
 			/>
 		{:else}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -632,6 +632,8 @@
 					onBreadcrumbNavigate={handleBreadcrumbNavigate}
 					onBreadcrumbContextMenu={handleBreadcrumbContextMenu}
 					onToggleEditor={() => uiStore.toggleRightSidebar()}
+					onReleaseImport={(release) => orchestratorLayer?.setPurchaseRelease(release)}
+					onReleaseOpenUrl={(release) => openUrl(release.url)}
 					scrollOffset={$playlistScrollOffsets.get(playlist.id) ?? 0}
 					onScrollChange={(offset) => uiStore.setPlaylistScrollOffset(playlist.id, offset)}
 				/>


### PR DESCRIPTION
## Related Issue

Closes #118 

## Checklist

- [x] Self-reviewed the diff
- [x] Tested locally
- [x] No unrelated changes included
